### PR TITLE
Profiling log

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -137,6 +137,7 @@ class RunProcessing(object):
 
     def __init__(self, task_id):
         """@param task_id: ID of the analyses to process."""
+        self.task_id = task_id
         self.task = Database().view_task(task_id).to_dict()
         self.analysis_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id))
         self.cfg = Config(cfg=os.path.join(CUCKOO_ROOT, "conf", "processing.conf"))
@@ -210,6 +211,7 @@ class RunProcessing(object):
         # module available. Its structure can be observed through the JSON
         # dump in the analysis' reports folder. (If jsondump is enabled.)
         # We friendly call this "fat dict".
+        log.debug("profiling:start:process::taskid %s" % self.task_id)
         results = {}
 
         # Order modules using the user-defined sequence number.
@@ -223,7 +225,9 @@ class RunProcessing(object):
 
             # Run every loaded processing module.
             for module in processing_list:
+                log.debug("profiling:start:process:%s:taskid %s" % (str(module)[8:-2], self.task_id))
                 result = self.process(module)
+                log.debug("profiling:stop:process:%s:taskid %s" % (str(module)[8:-2], self.task_id))
                 # If it provided some results, append it to the big results
                 # container.
                 if result:
@@ -232,12 +236,18 @@ class RunProcessing(object):
             log.info("No processing modules loaded")
 
         # Return the fat dict.
+        log.debug("profiling:stop:process::taskid %s" % self.task_id)
         return results
 
 class RunSignatures(object):
     """Run Signatures."""
 
-    def __init__(self, results):
+    def __init__(self, results, task_id="?"):
+        """
+        @param results: Results from processing to run signatures on
+        @param task_id: Optional task_id for logging
+        """
+        self.task_id = task_id
         self.results = results
 
     def _load_overlay(self):
@@ -346,6 +356,7 @@ class RunSignatures(object):
         return None
 
     def run(self):
+        log.debug("profiling:start:signatures::taskid %s" % self.task_id)
         # This will contain all the matched signatures.
         matched = []
 
@@ -431,7 +442,9 @@ class RunSignatures(object):
             log.debug("Running non-evented signatures")
 
             for signature in complete_list:
+                log.debug("profiling:start:signatures:%s:taskid %s" % (signature.name, self.task_id))
                 match = self.process(signature)
+                log.debug("profiling:stop:signatures:%s:taskid %s" % (signature.name, self.task_id))
                 # If the signature is matched, add it to the list.
                 if match:
                     matched.append(match)
@@ -443,6 +456,7 @@ class RunSignatures(object):
 
         # Sort the matched signatures by their severity level.
         matched.sort(key=lambda key: key["severity"])
+        log.debug("profiling:stop:signatures::taskid %s" % self.task_id)
 
 class RunReporting:
     """Reporting Engine.
@@ -454,6 +468,7 @@ class RunReporting:
 
     def __init__(self, task_id, results):
         """@param analysis_path: analysis folder path."""
+        self.task_id = task_id
         self.task = Database().view_task(task_id).to_dict()
         self.results = results
         self.analysis_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id))
@@ -513,6 +528,7 @@ class RunReporting:
         # represents at which position that module should be executed among
         # all the available ones. It can be used in the case where a
         # module requires another one to be already executed beforehand.
+        log.debug("profiling:start:reporting::taskid %s" % self.task_id)
         reporting_list = list_plugins(group="reporting")
 
         # Return if no reporting modules are loaded.
@@ -521,6 +537,9 @@ class RunReporting:
 
             # Run every loaded reporting module.
             for module in reporting_list:
+                log.debug("profiling:start:reporting:%s:taskid %s" % (str(module)[8:-2], self.task_id))
                 self.process(module)
+                log.debug("profiling:stop:reporting:%s:taskid %s" % (str(module)[8:-2], self.task_id))
         else:
             log.info("No reporting modules loaded")
+        log.debug("profiling:stop:reporting::taskid %s" % self.task_id)

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -325,7 +325,7 @@ class AnalysisManager(Thread):
     def process_results(self):
         """Process the analysis results and generate the enabled reports."""
         results = RunProcessing(task_id=self.task.id).run()
-        RunSignatures(results=results).run()
+        RunSignatures(results=results, task_id=self.task.id).run()
         RunReporting(task_id=self.task.id, results=results).run()
 
         # If the target is a file and the user enabled the option,

--- a/lib/cuckoo/core/startup.py
+++ b/lib/cuckoo/core/startup.py
@@ -140,11 +140,18 @@ class ConsoleHandler(logging.StreamHandler):
 
         logging.StreamHandler.emit(self, colored)
 
-def init_logging():
-    """Initializes logging."""
+def init_logging(logfile=None, dbhandler=True):
+    """Initializes logging.
+
+    @param logfile: An optional log file path
+    @param dbhandler: Add database handler to logging
+    """
     formatter = logging.Formatter("%(asctime)s [%(name)s] %(levelname)s: %(message)s")
 
-    fh = logging.handlers.WatchedFileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"))
+    if logfile is None:
+        fh = logging.handlers.WatchedFileHandler(os.path.join(CUCKOO_ROOT, "log", "cuckoo.log"))
+    else:
+        fh = logging.handlers.WatchedFileHandler(logfile)
     fh.setFormatter(formatter)
     log.addHandler(fh)
 
@@ -152,9 +159,10 @@ def init_logging():
     ch.setFormatter(formatter)
     log.addHandler(ch)
 
-    dh = DatabaseHandler()
-    dh.setLevel(logging.ERROR)
-    log.addHandler(dh)
+    if dbhandler:
+        dh = DatabaseHandler()
+        dh.setLevel(logging.ERROR)
+        log.addHandler(dh)
 
     log.setLevel(logging.INFO)
 

--- a/utils/process.py
+++ b/utils/process.py
@@ -16,14 +16,15 @@ log = logging.getLogger()
 sys.path.append(os.path.join(os.path.abspath(os.path.dirname(__file__)), ".."))
 
 from lib.cuckoo.common.config import Config
+from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.core.database import Database, TASK_REPORTED, TASK_COMPLETED
 from lib.cuckoo.core.database import TASK_FAILED_PROCESSING
 from lib.cuckoo.core.plugins import RunProcessing, RunSignatures, RunReporting
-from lib.cuckoo.core.startup import init_modules
+from lib.cuckoo.core.startup import init_modules, init_logging
 
 def do(aid, report=False):
     results = RunProcessing(task_id=aid).run()
-    RunSignatures(results=results).run()
+    RunSignatures(results=results, task_id=aid).run()
 
     if report:
         RunReporting(task_id=aid, results=results).run()
@@ -87,6 +88,8 @@ def main():
     parser.add_argument("-r", "--report", help="Re-generate report", action="store_true", required=False)
     parser.add_argument("-p", "--parallel", help="Number of parallel threads to use (auto mode only).", type=int, required=False, default=1)
     args = parser.parse_args()
+
+    init_logging(os.path.join(CUCKOO_ROOT, "log", "process.log"), False)
 
     if args.debug:
         log.setLevel(logging.DEBUG)

--- a/utils/stats.py
+++ b/utils/stats.py
@@ -47,7 +47,14 @@ def main():
         started = min(timestamp(task.started_on) for task in tasks)
 
         # Get the time when the last task completed.
-        completed = max(timestamp(task.completed_on) for task in tasks)
+        stamps = []
+        for task in tasks:
+            try:
+                stamps.append(timestamp(task.completed_on))
+            except AttributeError:
+                pass
+
+        completed = max(stamps)
 
         # Get the amount of tasks that actually completed.
         finished = len(tasks)


### PR DESCRIPTION
Adds more DEBUG log lines to the Cuckoo output (activate with cuckoo --debug). The log can be processed with "utils/stats.py --profile " and show how much time the process spent in where.