### PR TITLE
Cache for behavior processing. Large improvements in processing speed

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -81,6 +81,10 @@ analysis_size_limit = 104857600
 # Enable or disable DNS lookups.
 resolve_dns = on
 
+# Use ram to boost processing speed. You will need more than 20GB of RAM for this feature.
+# Please read "performance" section in the documentation.
+ram_boost = off
+
 [database]
 # Specify the database connection string.
 # Examples, see documentation for more:

--- a/docs/book/src/usage/index.rst
+++ b/docs/book/src/usage/index.rst
@@ -14,3 +14,4 @@ This chapter explains how to use Cuckoo.
     packages
     results
     utilities
+    performance

--- a/docs/book/src/usage/performance.rst
+++ b/docs/book/src/usage/performance.rst
@@ -1,0 +1,41 @@
+===========
+Performance
+===========
+
+There are several ways to tune the Cuckoo performance
+
+Processing
+==========
+
+Processing are the three steps after the malware executed in a VM. Those are
+
+* processing of raw data
+* signature matching
+* reporting
+
+Processing can take up to 30 minutes if the original raw log is large. This is caused by many API calls in that log. Several
+steps will iterate through that API list which causes a slow down. There are several ways to mitigate the impact:
+
+Evented signatures
+------------------
+
+Evented signatures have a common loop through the api calls. Use them wherever possible and either switch of the
+old-style signatures with their own api-call loop or convert them to event based signatures
+
+Reporting
+---------
+
+Reports that contain the API log will also iterate through the list. De-activate reports you do not need.
+For automated environments switching off the html report will be a good choice.
+
+Multi-Core processing
+---------------------
+
+By switching off processing ( *conf/cuckoo.conf*, ``process_results`` in ``[cuckoo]``) the processing step can
+be done in a separate *utils/process.py* task running several process.
+
+Ram-boost
+---------
+
+Ram boost can be switched on in the configuration (in *conf/cuckoo.conf* ``ram_boost`` in ``[processing]``).
+This will keep the whole API list in Ram. Do that only if you have plenty of Ram (>20 GB for 8 VMs).

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -46,20 +46,22 @@ class ParseProcessLog(list):
         self.first_seen = None
         self.calls = self
         self.lastcall = None
+        self.cfg = Config()
 
         if os.path.exists(log_path) and os.stat(log_path).st_size > 0:
             self.parse_first_and_reset()
 
-        self.api_call_cache = []
-        self.api_pointer = 0
+        if self.cfg.processing.ram_boost:
+            self.api_call_cache = []
+            self.api_pointer = 0
 
-        try:
-            while True:
-                i = self.real_next()
-                self.api_call_cache.append(i)
-        except StopIteration:
-            pass
-        self.api_call_cache.append(None)
+            try:
+                while True:
+                    i = self.real_next()
+                    self.api_call_cache.append(i)
+            except StopIteration:
+                pass
+            self.api_call_cache.append(None)
 
     def parse_first_and_reset(self):
         self.fd = open(self._log_path, "rb")
@@ -154,11 +156,14 @@ class ParseProcessLog(list):
         """ Just accessing the cache
         """
 
-        res = self.api_call_cache[self.api_pointer]
-        if res is None:
-            raise StopIteration()
-        self.api_pointer += 1
-        return res
+        if self.cfg.processing.ram_boost:
+            res = self.api_call_cache[self.api_pointer]
+            if res is None:
+                raise StopIteration()
+            self.api_pointer += 1
+            return res
+        else:
+            return self.real_next()
 
     def log_process(self, context, timestring, pid, ppid, modulepath, procname):
         self.process_id, self.parent_id, self.process_name = pid, ppid, procname

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -57,7 +57,7 @@ class ParseProcessLog(list):
 
             try:
                 while True:
-                    i = self.real_next()
+                    i = self.cacheless_next()
                     self.api_call_cache.append(i)
             except StopIteration:
                 pass
@@ -134,7 +134,7 @@ class ParseProcessLog(list):
 
         return True
 
-    def real_next(self):
+    def cacheless_next(self):
         if not self.fd:
             raise StopIteration()
 
@@ -163,7 +163,7 @@ class ParseProcessLog(list):
             self.api_pointer += 1
             return res
         else:
-            return self.real_next()
+            return self.cacheless_next()
 
     def log_process(self, context, timestring, pid, ppid, modulepath, procname):
         self.process_id, self.parent_id, self.process_name = pid, ppid, procname


### PR DESCRIPTION
The API data is processed only once. The results are taken from the memory cache. Processing of one of my insane analyses went from 30 minutes to 11. Adding ~ 600MB to RAM usage. (the json report is 300MB, so this is a very special case). And it scales better with a growing number of signatures or reporting modules. Normal test cases show similar results.