### PR TITLE
Modified processing results from dict to defaultdict

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -212,7 +212,7 @@ class RunProcessing(object):
         # module available. Its structure can be observed through the JSON
         # dump in the analysis' reports folder. (If jsondump is enabled.)
         # We friendly call this "fat dict".
-        results = {}
+        results = defaultdict(dict)
 
         # Order modules using the user-defined sequence number.
         # If none is specified for the modules, they are selected in


### PR DESCRIPTION
Failed to generate HTML report with 'dict object' has no attribute 'static'.
This is why ReportHTML try to access to the key that dictionary does not have.