### PR TITLE
Added creation/deletion of registry keys to static HTML report summary

### DIFF
--- a/data/html/sections/behavior.html
+++ b/data/html/sections/behavior.html
@@ -45,10 +45,20 @@
         </div>
         <div class="well well-small">
             <b>Registry Keys</b>
-            {% if results.behavior.summary["keys"] %}
-                <ul>
-                    {% for key in results.behavior.summary["keys"] %}
-                    <li><span class="mono">{{key}}</span></li>
+            {% if results.behavior.enhanced.registry_events %}
+                <ul style="list-style: none;">
+                    {% for event in results.behavior.enhanced.registry_events %}
+                        {% if event['event'] == 'read' %}
+                            <li><span class="mono">{{event['regkey']}}</span></li>
+                        {% elif event['event'] == 'delete' %}
+                            <li style=color:red><span class="mono">- {{event['regkey']}}</span></li>
+                        {% elif event['event'] == 'write' %}
+                        <li style=color:green><span class="mono">w+ {{event['regkey']}}
+                            <ul>
+                                <li style=color:green><span class="mono">{{event['content']}}</li>
+                            </ul>
+                        </span></li>
+                        {% endif %}
                     {% endfor %}
                 </ul>
             {% else %}

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -795,16 +795,16 @@ class Enhanced(object):
                 event["data"]["file"] = _get_handle(self.filehandles, args["FileHandle"])
 
             elif call["api"] in ["RegDeleteKeyA", "RegDeleteKeyW"]:
-                event["data"]["regkey"] = "{0}{1}".format(self._get_keyhandle(args.get("Handle", "")), args.get("SubKey", ""))
+                event["data"]["regkey"] = "{0}\{1}".format(self._get_keyhandle(args.get("Handle", "")), args.get("SubKey", ""))
 
             elif call["api"] in ["RegSetValueExA", "RegSetValueExW"]:
-                event["data"]["regkey"] = "{0}{1}".format(self._get_keyhandle(args.get("Handle", "")), args.get("ValueName", ""))
+                event["data"]["regkey"] = "{0}\{1}".format(self._get_keyhandle(args.get("Handle", "")), args.get("ValueName", ""))
 
             elif call["api"] in ["RegQueryValueExA", "RegQueryValueExW", "RegDeleteValueA", "RegDeleteValueW"]:
-                event["data"]["regkey"] = "{0}{1}".format(self._get_keyhandle(args.get("Handle", "UNKNOWN")), args.get("ValueName", ""))
+                event["data"]["regkey"] = "{0}\{1}".format(self._get_keyhandle(args.get("Handle", "UNKNOWN")), args.get("ValueName", ""))
 
             elif call["api"] in ["NtQueryValueKey", "NtDeleteValueKey"]:
-                event["data"]["regkey"] = "{0}{1}".format(self._get_keyhandle(args.get("KeyHandle", "UNKNOWN")), args.get("ValueName", ""))
+                event["data"]["regkey"] = "{0}\{1}".format(self._get_keyhandle(args.get("KeyHandle", "UNKNOWN")), args.get("ValueName", ""))
 
             elif call["api"] in ["LoadLibraryA", "LoadLibraryW", "LoadLibraryExA", "LoadLibraryExW", "LdrGetDllHandle"] and call["status"]:
                 self._add_loaded_module(args.get("FileName", ""), args.get("ModuleHandle", ""))

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -424,6 +424,33 @@ class Enhanced(object):
         self.modules = {}
         self.procedures = {}
         self.events = []
+        self.regevents = []
+
+    def _handle_registry_event(self, event):
+        """
+        Adds keys to new data structure for better display in the 
+        web GUI
+        """
+        if event['object'] != 'registry':
+            return
+
+        else:
+            if event['event'] == 'write':
+                reg_event = {
+                                "event": event['event'],
+                                "regkey": event['data']['regkey'],
+                                "content": event['data']['content'].replace('\\x00','')
+                            }
+            else:
+                reg_event = {
+                                "event": event['event'],
+                                "regkey": event['data']['regkey'],
+                                "content": ""
+                            }
+            if reg_event not in self.regevents:
+                self.regevents.append(reg_event)
+
+        return
 
     def _add_procedure(self, mbase, name, base):
         """
@@ -836,12 +863,13 @@ class Enhanced(object):
         event = self._process_call(call)
         if event:
             self.events.append(event)
+            self._handle_registry_event(event)
 
     def run(self):
         """Get registry keys, mutexes and files.
         @return: Summary of keys, mutexes and files.
         """
-        return self.events
+        return {"enhanced_events": self.events, "registry_events": self.regevents}
 
 
 class Anomaly(object):

--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -425,16 +425,15 @@ class Enhanced(object):
         self.procedures = {}
         self.events = []
         self.regevents = []
+        self.fileevents = []
+        self.direvents = []
 
-    def _handle_registry_event(self, event):
+    def _handle_enhanced_event(self, event):
         """
         Adds keys to new data structure for better display in the 
         web GUI
         """
-        if event['object'] != 'registry':
-            return
-
-        else:
+        if event['object'] == 'registry':
             if event['event'] == 'write':
                 reg_event = {
                                 "event": event['event'],
@@ -449,6 +448,31 @@ class Enhanced(object):
                             }
             if reg_event not in self.regevents:
                 self.regevents.append(reg_event)
+
+        if event['object'] == 'file':
+            if event['event'] == 'move':
+                file_event = {
+                                "event": event['event'],
+                                "to": event['data']['to'],
+                                "file": event['data']['to'],
+                                "from": event['data']['from']
+                             }
+
+            else:
+                file_event = {
+                                "event": event['event'],
+                                "file": event['data']['file']
+                             }
+            if file_event not in self.fileevents:
+                self.fileevents.append(file_event)
+
+        if event['object'] == 'dir':
+            dir_event = {
+                            "event": event['event'],
+                            "dir": event['data']['file']
+                        }
+            if dir_event not in self.direvents:
+                self.direvents.append(dir_event)
 
         return
 
@@ -863,13 +887,13 @@ class Enhanced(object):
         event = self._process_call(call)
         if event:
             self.events.append(event)
-            self._handle_registry_event(event)
+            self._handle_enhanced_event(event)
 
     def run(self):
         """Get registry keys, mutexes and files.
         @return: Summary of keys, mutexes and files.
         """
-        return {"enhanced_events": self.events, "registry_events": self.regevents}
+        return {"enhanced_events": self.events, "registry_events": self.regevents, "file_events": self.fileevents, "dir_events": self.direvents}
 
 
 class Anomaly(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ pefile
 django
 chardet
 nose
-testing3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pefile
 django
 chardet
 nose
+testing3

--- a/web/templates/analysis/overview/_summary.html
+++ b/web/templates/analysis/overview/_summary.html
@@ -9,24 +9,63 @@
         <div class="tab-content">
             <div class="tab-pane fade in active" id="summary_files">
                 <div class="well mono">
-                {% if analysis.behavior.summary.files %}
-                    {% for file in analysis.behavior.summary.files %}
-                        {{file}}<br />
+                {% if analysis.behavior.enhanced.dir_events %}
+                    <ul style="list-style: none; padding-left:0;">
+                    {% for event in analysis.behavior.enhanced.dir_events %}
+                        {% if event.event == 'delete' %}
+                            <li style=color:red>delete dir {{event.dir}}</li>
+                        {% elif event.event == 'create' %}
+                            <li style=color:green>create dir {{event.dir}}</li>
+                        {% else %}
+                            <li>{{event.event}} {{event.dir}}</li>
+                        {% endif %}
                     {% endfor %}
+                    </ul>
                 {% endif %}
+                {% if analysis.behavior.enhanced.file_events %}
+                    <ul style="list-style: none; padding-left:0;">
+                    {% for event in analysis.behavior.enhanced.file_events %}
+                        {% if event.event == 'delete' %}
+                            <li style=color:red>delete {{event.file}}</li>
+                        {% elif event.event == 'write' %}
+                            <li style=color:green>write {{event.file}}</li>
+                        {% elif event.event == 'execute' %}
+                            <li style=color:purple>execute {{event.file}}</li>
+                        {% elif event.event == 'move' %}
+                            <li>move <div style=color:red>{{event.from}}</div> to <div style=color:green>{{event.to}}</div></li>
+                        {% else %}
+                            <li>{{event.event}} {{event.file}}</li>
+                        {% endif %}
+                    {% endfor %}
+                    </ul>
+                {% endif %}
+               
                 </div>
             </div>
             <div class="tab-pane fade" id="summary_keys">
                 <div class="well mono">
-                {% if analysis.behavior.summary.keys %}
-                    {% for key in analysis.behavior.summary.keys %}
-                        {{key}}<br />
-                    {% endfor %}
+                {% if analysis.behavior.enhanced.registry_events %}
+                    <ul style="list-style: none; padding-left:0;">
+                        {% for event in analysis.behavior.enhanced.registry_events %}
+                            {% if event.event == 'read' %}
+                                <li><span class="mono">{{event.regkey}}</span></li>
+                            {% elif event.event == 'delete' %}
+                                <li style=color:red><span class="mono">- {{event.regkey}}</span></li>
+                            {% elif event.event == 'write' %}
+                                <li style=color:green><span class="mono">w+ {{event.regkey}}
+                                    <ul>
+                                        <li style=color:green><span class="mono">{{event.content}}</li>
+                                    </ul>
+                                </span></li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
                 {% endif %}
                 </div>
             </div>
             <div class="tab-pane fade" id="summary_mutexes">
                 <div class="well mono">
+                {{ analysis.behavior.enhanced }} 
                 {% if analysis.behavior.summary.mutexes %}
                     {% for mutex in analysis.behavior.summary.mutexes %}
                         {{mutex}}<br />


### PR DESCRIPTION
These changes allow for more detailed information about the registry to be displayed in the web gui. It does not differentiate between key addition and modification and so treats all writes the same. Writes have green text and are prefixed with 'w+', deletions have red text and are prefixed with '-'. An example is below:

![stry](https://cloud.githubusercontent.com/assets/5605916/5071798/34f6f7a0-6e42-11e4-98bc-e12ae1aa2113.png)
