### PR TITLE
Update installation.rst

### DIFF
--- a/docs/book/src/installation/host/installation.rst
+++ b/docs/book/src/installation/host/installation.rst
@@ -21,13 +21,13 @@ Create a new user::
 If you're using VirtualBox, make sure the new user belongs to the "vboxusers"
 group (or the group you used to run VirtualBox)::
 
-    $ sudo usermod -G vboxusers cuckoo
+    $ sudo usermod -a -G vboxusers cuckoo
 
 If you're using KVM or any other libvirt based module, make sure the new user
 belongs to the "libvirtd" group (or the group your Linux distribution uses to
 run libvirt)::
 
-    $ sudo usermod -G libvirtd cuckoo
+    $ sudo usermod -a -G libvirtd cuckoo
 
 Install Cuckoo
 ==============


### PR DESCRIPTION
From the man page of usermod for the option -G: "If the user is currently a member of a group which is not listed, the user will be removed from the group. This behaviour can be changed via the -a option, which appends the user to the current supplementary group list." In my case the usermod command without the -a removed me from all other groups I was in and set my gropus to e.g. vboxusers.