### PR TITLE
Use context manager on jsondump.py

### DIFF
--- a/modules/reporting/jsondump.py
+++ b/modules/reporting/jsondump.py
@@ -22,9 +22,8 @@ class JsonDump(Report):
 
         try:
             path = os.path.join(self.reports_path, "report.json")
-            report = codecs.open(path, "w", "utf-8")
-            json.dump(results, report, sort_keys=False,
-                      indent=int(indent), encoding=encoding)
-            report.close()
+            with codecs.open(path, "w", "utf-8") as report:
+                json.dump(results, report, sort_keys=False,
+                          indent=int(indent), encoding=encoding)
         except (UnicodeError, TypeError, IOError) as e:
             raise CuckooReportError("Failed to generate JSON report: %s" % e)


### PR DESCRIPTION
Not using context managers and doing that try/catch without a finally closing the file ended up sometimes in jsons being broken.
I suspect that was because of encoding problems that would've been fixed by using encoding=, but leaving open file descriptors is not good anyway.