### PR TITLE
Running generic files

### DIFF
--- a/analyzer/windows/modules/packages/generic.py
+++ b/analyzer/windows/modules/packages/generic.py
@@ -12,5 +12,5 @@ class Generic(Package):
 
     def start(self, path):
         cmd_path = self.get_path("cmd.exe")
-        cmd_args = "/c start \"{0}\"".format(path)
+        cmd_args = "/c start "Title" \"{0}\"".format(path)
         return self.execute(cmd_path, cmd_args)


### PR DESCRIPTION
Running 'cmd /c start "calc.exe"' just opens a Command Line with the title of 'calc.exe' instead of running 'calc.exe' ("calc.exe" is handled as the title and not the command/program.) we just need to define a title to fix it.
the syntax of 'start' command in windows is:
START ["title"] [/D path] [/I] [/MIN] [/MAX] [/SEPARATE | /SHARED]
      [/LOW | /NORMAL | /HIGH | /REALTIME | /ABOVENORMAL | /BELOWNORMAL]
      [/NODE <NUMA node>] [/AFFINITY <hex affinity mask>] [/WAIT] [/B]
      [command/program] [parameters]