### PR TITLE
Fix up --clean for MySQL

### DIFF
--- a/cuckoo.py
+++ b/cuckoo.py
@@ -100,6 +100,12 @@ def cuckoo_clean():
     # Initialize the database connection.
     db = Database()
 
+    # Drop machines and machines_tags.
+    db.clean_machines()
+    
+    # Drop all guests.
+    db.drop_guests()
+    
     # Drop all tasks.
     db.drop_tasks()
 

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -436,11 +436,27 @@ class Database(object):
             session.close()
 
     @classlock
+    def drop_guests(self):
+        """Drop all guests and their associated information."""
+        session = self.Session()
+        try:
+            session.query(Guest).delete()
+            session.commit()
+        except SQLAlchemyError as e:
+            log.warning("Database error dropping all guests: %s", e)
+            session.rollback()
+            return False
+        finally:
+            session.close()
+        return True
+
+    @classlock
     def drop_samples(self):
         """Drop all samples and their associated information."""
         session = self.Session()
         try:
             session.query(Sample).delete()
+            session.commit()
         except SQLAlchemyError as e:
             log.debug("Database error dropping all samples: %s", e)
             session.rollback()
@@ -455,6 +471,7 @@ class Database(object):
         session = self.Session()
         try:
             session.query(Task).delete()
+            session.commit()
         except SQLAlchemyError as e:
             log.debug("Database error dropping all tasks: %s", e)
             session.rollback()


### PR DESCRIPTION
Added a function to drop guests as there was an issue in MySQL where we couldn't delete the samples table due to a FK constraint with tasks, which had a FK contraint to the guest table. We also drop the machines-related tables; should probably drop errors and tags tables in a future commit to be truly clean. We were also missing commits to the drop statements for the samples and tasks tables. These errors were invisible due to the missing log handler, which I have logged under issue #453.