### PR TITLE
Add MSI Analyzer Package

### DIFF
--- a/analyzer/windows/lib/core/packages.py
+++ b/analyzer/windows/lib/core/packages.py
@@ -44,5 +44,7 @@ def choose_package(file_type, file_name):
         return "python"
     elif file_name.endswith(".vbs"):
         return "vbs"
+    elif file_name.endswith(".msi"):
+        return "msi"
     else:
         return "generic"

--- a/analyzer/windows/modules/packages/msi.py
+++ b/analyzer/windows/modules/packages/msi.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2010-2015 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+from lib.common.abstracts import Package
+
+class Msi(Package):
+    """MSI analysis package."""
+    PATHS = [
+        ("SystemRoot", "system32", "msiexec.exe"),
+    ]
+
+    def start(self, path):
+        msi_path = self.get_path("msiexec.exe")
+        msi_args = "/I \"{0}\"".format(path)
+        return self.execute(msi_path, msi_args, path)


### PR DESCRIPTION
Create an MSI analyzer package using msiexec.exe. Add a detection to automatically use the package for files submitted with a .msi extension. (File magic is unreliable)