### PR TITLE
Allow --clean to drop MongoDB database

### DIFF
--- a/cuckoo.py
+++ b/cuckoo.py
@@ -11,6 +11,7 @@ import sys
 
 try:
     from lib.cuckoo.common.logo import logo
+    from lib.cuckoo.common.config import Config
     from lib.cuckoo.common.constants import CUCKOO_VERSION, CUCKOO_ROOT
     from lib.cuckoo.common.exceptions import CuckooCriticalError
     from lib.cuckoo.common.exceptions import CuckooDependencyError
@@ -81,6 +82,21 @@ def cuckoo_clean():
 
     # Drop all tables.
     db.drop()
+
+    # Check if MongoDB reporting is enabled and drop that if it is.
+    cfg = Config("reporting")
+    if cfg.mongodb:
+        if cfg.mongodb.enabled:
+            from pymongo import MongoClient
+            host = cfg.mongodb.host
+            port = cfg.mongodb.port
+            mdb = cfg.mongodb.db
+            try:
+                conn = MongoClient(host, port)
+                conn.drop_database(mdb)
+                conn.disconnect()
+            except:
+                log.warning("Unable to drop MongoDB Database: %s", mdb)
 
     # Paths to clean
     paths = [


### PR DESCRIPTION
Load the reporting config and drop the MongoDB database if we're configured to use it.