### PR TITLE
Add an open button and use a button blacklist.

### DIFF
--- a/analyzer/windows/modules/auxiliary/human.py
+++ b/analyzer/windows/modules/auxiliary/human.py
@@ -36,8 +36,13 @@ def foreach_child(hwnd, lparam):
         "don't send",
         "continue",
         "unzip",
+        "open",
     ]
-
+    
+    dontclick = [
+        "don't run",
+    ]
+    
     classname = create_unicode_buffer(50)
     USER32.GetClassNameW(hwnd, classname, 50)
 
@@ -51,6 +56,9 @@ def foreach_child(hwnd, lparam):
         # Check if the button is "positive".
         for button in buttons:
             if button in text.value.lower():
+                for btn in dontclick:
+                    if btn in text.value.lower():
+                        return False
                 log.info("Found button \"%s\", clicking it" % text.value)
                 USER32.SetForegroundWindow(hwnd)
                 KERNEL32.Sleep(1000)


### PR DESCRIPTION
This fixes a bug/race condition for when we have a window with two buttons: Run and Don't Run. Cuckoo would sometimes end up clicking Don't Run as "run" was in the button text. The introduction of a black list allows us to be more explicit. Also add the 'open' button for windows where our only choices are 'open', 'open folder', or 'cancel'. (In the case of running JavaScript files with IE)