### PR TITLE
Modified REST API Bottle usage to optionally run as WSGI app

### DIFF
--- a/utils/web.py
+++ b/utils/web.py
@@ -15,13 +15,13 @@ try:
     from jinja2.loaders import FileSystemLoader
     from jinja2.environment import Environment
 except ImportError:
-    sys.stderr.write("ERROR: Jinja2 library is missing")
+    print >> sys.stderr, "ERROR: Jinja2 library is missing"
     sys.exit(1)
 try:
     from bottle import route, run, static_file, request
-    from bottle import HTTPError, hook, response
+    from bottle import Bottle, HTTPError, hook, response
 except ImportError:
-    sys.stderr.write("ERROR: Bottle library is missing")
+    print >> sys.stderr, "ERROR: Bottle library is missing"
     sys.exit(1)
 
 logging.basicConfig()
@@ -31,6 +31,8 @@ from lib.cuckoo.common.constants import CUCKOO_ROOT
 from lib.cuckoo.common.utils import store_temp_file
 from lib.cuckoo.core.database import Database
 from lib.cuckoo.core.startup import drop_privileges
+
+app = application = Bottle()
 
 # Templating engine.
 env = Environment()
@@ -95,7 +97,7 @@ def get_pagination_limit(new_limit):
 
     return limit
 
-@hook("after_request")
+@app.hook("after_request")
 def custom_headers():
     """Set some custom headers across all HTTP responses."""
     response.headers["Server"] = "Machete Server"
@@ -106,13 +108,13 @@ def custom_headers():
     response.headers["Cache-Control"] = "no-cache"
     response.headers["Expires"] = "0"
 
-@route("/")
+@app.route("/")
 def index():
     context = {}
     template = env.get_template("submit.html")
     return template.render({"context": context, "machines": [m.name for m in db.list_machines()]})
 
-@route("/browse")
+@app.route("/browse")
 def browse():
     rows = db.list_tasks()
 
@@ -122,11 +124,11 @@ def browse():
 
     return template.render({"rows": tasks, "os": os})
 
-@route("/browse/page")
-@route("/browse/page/")
-@route("/browse/page/<page_id:int>")
-@route("/browse/page/<page_id:int>/")
-@route("/browse/page/<page_id:int>/<new_limit:int>")
+@app.route("/browse/page")
+@app.route("/browse/page/")
+@app.route("/browse/page/<page_id:int>")
+@app.route("/browse/page/<page_id:int>/")
+@app.route("/browse/page/<page_id:int>/<new_limit:int>")
 def browse_page(page_id=1, new_limit=-1):
     if page_id < 1:
         page_id = 1
@@ -166,11 +168,11 @@ def browse_page(page_id=1, new_limit=-1):
 
     return template.render({"rows": tasks, "os": os, "pagination": pagination})
 
-@route("/static/<filename:path>")
+@app.route("/static/<filename:path>")
 def server_static(filename):
     return static_file(filename, root=os.path.join(CUCKOO_ROOT, "data", "html"))
 
-@route("/submit", method="POST")
+@app.route("/submit", method="POST")
 def submit():
     context = {}
     errors = False
@@ -222,7 +224,7 @@ def submit():
         template = env.get_template("error.html")
         return template.render({"error": "The server encountered an internal error while submitting {0}".format(data.filename.decode("utf-8"))})
 
-@route("/view/<task_id>/download")
+@app.route("/view/<task_id>/download")
 def downlaod_report(task_id):
     if not task_id.isdigit():
         return HTTPError(code=404, output="The specified ID is invalid")
@@ -237,7 +239,7 @@ def downlaod_report(task_id):
 
     return open(report_path, "rb").read()
 
-@route("/view/<task_id>")
+@app.route("/view/<task_id>")
 def view(task_id):
     if not task_id.isdigit():
         return HTTPError(code=404, output="The specified ID is invalid")
@@ -249,7 +251,7 @@ def view(task_id):
 
     return open(report_path, "rb").read().replace("<!-- BOTTLEREMOVEME", "").replace("BOTTLEREMOVEME --!>", "")
 
-@route("/pcap/<task_id>")
+@app.route("/pcap/<task_id>")
 def get_pcap(task_id):
     if not task_id.isdigit():
         return HTTPError(code=404, output="The specified ID is invalid")
@@ -264,7 +266,7 @@ def get_pcap(task_id):
 
     return open(pcap_path, "rb").read()
 
-@route("/files/<task_id>")
+@app.route("/files/<task_id>")
 def get_files(task_id):
     if not task_id.isdigit():
         return HTTPError(code=404, output="The specified ID is invalid")
@@ -298,4 +300,4 @@ if __name__ == "__main__":
     if args.user:
         drop_privileges(args.user)
 
-    run(host=args.host, port=args.port, reloader=True)
+    run(app, host=args.host, port=args.port, reloader=True)


### PR DESCRIPTION
Modified Bottle usage in web.py to optionally run as WSGI app by exposing application callable. I'm not sure that this is correctly implemented but it launches in both modes without error; hopefully the beginning of something useful:

1. Standalone as before, by launching utils/web.py directly:

        $ python utils/web.py --port 6666
        Bottle v0.12.0 server starting up (using WSGIRefServer())...
        Listening on http://0.0.0.0:6666/
        Hit Ctrl-C to quit.

2. As WSGI application using uWSGI:

        # test.ini
        [uwsgi]
        http-socket = 127.0.0.1:6666
        master = true
        plugins = python
        file = /home/cuckoo/cuckoo/utils/web.py

Launched with `uwsgi  --enable-threads --ini test.ini`

Borrowed technique from https://michael.lustfield.net/nginx/bottle-uwsgi-nginx-quickstart.

Trying to nail this down as I'd prefer to run the API service in a productionized web deployment stack, i.e. uWSGI + Nginx similar to how we run the Cuckoo web UI.

Minor other update to output import error messages on stderr with newlines.