### PR TITLE
Added brief documentation on setting up API server to run as a WSGI app.

### DIFF
--- a/docs/book/src/usage/api.rst
+++ b/docs/book/src/usage/api.rst
@@ -81,7 +81,7 @@ Nginx setup
 With the API server running in uWSGI, Nginx can now be set up to run as a web
 server/reverse proxy, backending HTTP requests to it.
 
-To begin, create a Nginx configuration file at ``/etc/uwsgi/apps-available/cuckoo-api.ini``::
+To begin, create a Nginx configuration file at ``/etc/nginx/sites-available/cuckoo-api``::
 
     upstream _uwsgi_cuckoo_api {
         server unix:/run/uwsgi/app/cuckoo-api/socket;

--- a/docs/book/src/usage/api.rst
+++ b/docs/book/src/usage/api.rst
@@ -27,6 +27,96 @@ By default it will bind the service on **localhost:8090**. If you want to change
 
     $ ./utils/api.py --host 0.0.0.0 --port 1337
 
+Web deployment
+--------------
+
+While the default method of starting the API server works fine for many cases, 
+some users may wish to deploy the server in a robust manner. This can be done 
+by exposing the API as a WSGI application through a web server. This section shows 
+a simple example of deploying the API via `uWSGI`_ and `Nginx`_. These 
+instructions are written with Ubuntu GNU/Linux in mind, but may be adapted for 
+other platforms.
+
+This solution requires uWSGI, the uWSGI Python plugin, and Nginx. All are available as packages::
+
+    $ sudo apt-get install uwsgi uwsgi-plugin-python nginx
+
+uWSGI setup
+^^^^^^^^^^^
+First, use uWSGI to run the API server as an application.
+
+To begin, create a uWSGI configuration file at ``/etc/uwsgi/apps-available/cuckoo-api.ini``::
+
+    [uwsgi]
+    plugins = python
+    chdir = /home/cuckoo/cuckoo
+    file = utils/web.py
+    uid = cuckoo
+    gid = cuckoo
+
+This configuration inherits a number of settings from the distribution's 
+default uWSGI configuration, loading ``web.py`` from the Cuckoo installation 
+directory. If Cuckoo is installed in a different path, adjust the configuration 
+(the *chdir* setting, and perhaps the *uid* and *gid* settings) accordingly.
+
+Enable the app configuration and start the server::
+
+    $ sudo ln -s /etc/uwsgi/apps-available/cuckoo-api.ini /etc/uwsgi/apps-enabled/
+    $ sudo service uwsgi start cuckoo-api    # or reload, if already running
+
+.. note::
+
+   Logs for the application may be found in the standard directory for distribution
+   app instances, i.e.:
+
+   ``/var/log/uwsgi/app/cuckoo-api.log``
+
+   The UNIX socket is created in a conventional location as well:
+
+   ``/run/uwsgi/app/cuckoo-api/socket``
+
+Nginx setup
+^^^^^^^^^^^
+
+With the API server running in uWSGI, Nginx can now be set up to run as a web
+server/reverse proxy, backending HTTP requests to it.
+
+To begin, create a Nginx configuration file at ``/etc/uwsgi/apps-available/cuckoo-api.ini``::
+
+    upstream _uwsgi_cuckoo_api {
+        server unix:/run/uwsgi/app/cuckoo-api/socket;
+    }
+
+    # HTTP server
+    #
+    server {
+        listen 8090;
+        listen [::]:8090 ipv6only=on;
+
+        # REST API app
+        location / {
+            uwsgi_pass  _uwsgi_cuckoo_api;
+            include     uwsgi_params;
+        }
+    }
+
+Make sure that Nginx can connect to the uWSGI socket by placing its user in the **cuckoo** group::
+
+    $ sudo adduser www-data cuckoo
+
+Enable the server configuration and start the server::
+
+    $ sudo ln -s /etc/nginx/sites-available/cuckoo-api /etc/nginx/sites-enabled/
+    $ sudo service nginx start    # or reload, if already running
+
+At this point, the API server should be available at port **8090** on the server.
+Various configurations may be applied to extend this configuration, such as to
+tune server performance, add authentication, or to secure communications using
+HTTPS.
+
+.. _`uWSGI`: http://uwsgi-docs.readthedocs.org/en/latest/
+.. _`Nginx`: http://nginx.org/
+
 Resources
 =========
 


### PR DESCRIPTION
Please review. See #517.