### PR TITLE
as of pymongo 3.0, Database.disconnect() as been removed as a synonym for Database.close().

### DIFF
--- a/modules/reporting/mongodb.py
+++ b/modules/reporting/mongodb.py
@@ -213,4 +213,4 @@ class MongoDB(Report):
 
         # Store the report and retrieve its object id.
         self.db.analysis.save(report)
-        self.conn.disconnect()
+        self.conn.close()


### PR DESCRIPTION
 fixes #522