### PR TITLE
prototype of a hook mechanism to integrate cuckoo task analysis without polling the API

### DIFF
--- a/conf/cuckoo.conf
+++ b/conf/cuckoo.conf
@@ -57,6 +57,12 @@ freespace = 64
 # (web.py, api.py, Django web interface).
 tmppath = /tmp
 
+# cuckoo webhook callback when analysis is complete
+webhook = on
+
+# url to POST to
+webhook_url = http://127.0.0.1
+
 [resultserver]
 # The Result Server is used to receive in real time the behavioral logs
 # produced by the analyzer.


### PR DESCRIPTION
not a real pull request per se, more of a prototype to gauge external interest.

i'm integrating cuckoo support in an application we're developing, and all our "resolvers" are asynchronous. as i'd like to limit polling, i'm implementing a hook mechanism to let cuckoo tell an external url when an analysis is complete.

i made a very primitive listener that waits for a POST containing a json dict with ```{'task': <id>}``` and gets ```tasks/report/<id>```

the real mechanism will probably be more [resthooks](http://resthooks.org/) like, with a real subscription mechanism for workers.

what would be your requirements for such a mechanism to be implemented in mainline ?

as a side note, the cuckoo code currently mixes calls to urllib2 and requests, i do not know if there is an 'official' position on which library to use, but i'd advise definitively switching to requests which makes for easier and cleaner code IMHO. 