### PR TITLE
fix bug: cuckoo can't load machinery plugins rightly.

### DIFF
--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -10,7 +10,7 @@ import logging
 from collections import defaultdict
 from distutils.version import StrictVersion
 
-from lib.cuckoo.common.abstracts import Auxiliary, Machinery, Processing
+from lib.cuckoo.common.abstracts import Auxiliary, Machinery, LibVirtMachinery, Processing
 from lib.cuckoo.common.abstracts import Report, Signature
 from lib.cuckoo.common.config import Config
 from lib.cuckoo.common.constants import CUCKOO_ROOT, CUCKOO_VERSION
@@ -47,7 +47,7 @@ def load_plugins(module):
         if inspect.isclass(value):
             if issubclass(value, Auxiliary) and value is not Auxiliary:
                 register_plugin("auxiliary", value)
-            elif issubclass(value, Machinery) and value is not Machinery:
+            elif issubclass(value, Machinery) and value is not Machinery and value is not LibVirtMachinery:
                 register_plugin("machinery", value)
             elif issubclass(value, Processing) and value is not Processing:
                 register_plugin("processing", value)


### PR DESCRIPTION
When I create a new machinery module xen, I find that cuckoo can't load machinery plugins rightly.

Run cuckoo with xen in debug mode:
```
$ python cuckoo.py -d
2015-05-14 03:02:55,276 [root] DEBUG: Imported "machinery" modules:
2015-05-14 03:02:55,276 [root] DEBUG:      |-- LibVirtMachinery
2015-05-14 03:02:55,276 [root] DEBUG:      `-- XEN
```
cuckoo loads machierny plugins LibVirtMachinery and XEN, the scheduler will use LibVirtMachinery but not Xen(lib/cuckoo/core/scheduler.py):
```Python
        # Get registered class name. Only one machine manager is imported,
        # therefore there should be only one class in the list.
        plugin = list_plugins("machinery")[0]
```
Although the KVM can run rightly, it also has potential error.

```
$ python cuckoo.py -d
2015-05-14 03:01:23,606 [root] DEBUG: Imported "machinery" modules:
2015-05-14 03:01:23,606 [root] DEBUG: 	 |-- KVM
2015-05-14 03:01:23,606 [root] DEBUG: 	 `-- LibVirtMachinery
```
After fix this bug:
```
$ python cuckoo.py -d
2015-05-14 03:16:44,685 [root] DEBUG: Imported "machinery" modules:
2015-05-14 03:16:44,685 [root] DEBUG: 	 `-- XEN
```