### PR TITLE
#554: Analyzer does not find 64 bit executables when python is 32 bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,9 +24,14 @@ Thumbs.db
 # Ignore development files
 docs/book/src/_build/
 .idea/
+.project
+.pydevproject
 
 # Ignore Django secret_key
 web/web/secret_key.py
 
 # Ignore yara rules
 data/yara/index_*.yar
+
+# Ignore venv
+venv

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -39,7 +39,10 @@ class Package(object):
             if basedir == "SystemRoot":
                 yield os.path.join(os.getenv("SystemRoot"), *path[1:])
             elif basedir == "ProgramFiles":
-                yield os.path.join(os.getenv("ProgramFiles"), *path[1:])
+		program_files = os.getenv("ProgramFiles")
+                yield os.path.join(program_files, *path[1:])
+		if program_files.lower().endswith(' (x86)'):
+                    yield os.path.join(program_files[:-6], *path[1:])
                 if os.getenv("ProgramFiles(x86)"):
                     yield os.path.join(os.getenv("ProgramFiles(x86)"),
                                        *path[1:])

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -39,10 +39,7 @@ class Package(object):
             if basedir == "SystemRoot":
                 yield os.path.join(os.getenv("SystemRoot"), *path[1:])
             elif basedir == "ProgramFiles":
-                program_files = os.getenv("ProgramFiles")
-                yield os.path.join(program_files, *path[1:])
-                if program_files.lower().endswith(' (x86)'):
-                    yield os.path.join(program_files[:-6], *path[1:])
+                yield os.path.join(os.getenv("ProgramFiles").replace(" (x86)", ""), *path[1:])
                 if os.getenv("ProgramFiles(x86)"):
                     yield os.path.join(os.getenv("ProgramFiles(x86)"),
                                        *path[1:])

--- a/analyzer/windows/lib/common/abstracts.py
+++ b/analyzer/windows/lib/common/abstracts.py
@@ -39,9 +39,9 @@ class Package(object):
             if basedir == "SystemRoot":
                 yield os.path.join(os.getenv("SystemRoot"), *path[1:])
             elif basedir == "ProgramFiles":
-		program_files = os.getenv("ProgramFiles")
+                program_files = os.getenv("ProgramFiles")
                 yield os.path.join(program_files, *path[1:])
-		if program_files.lower().endswith(' (x86)'):
+                if program_files.lower().endswith(' (x86)'):
                     yield os.path.join(program_files[:-6], *path[1:])
                 if os.getenv("ProgramFiles(x86)"):
                     yield os.path.join(os.getenv("ProgramFiles(x86)"),


### PR DESCRIPTION
If %ProgramFiles% resolves to C:\Program Files (x86), we should still yield C:\Program Files. Fixes issue: https://github.com/cuckoobox/cuckoo/issues/554