### PR TITLE
Added ability to track volatility profiles at the machine level.

### DIFF
--- a/conf/esx.conf
+++ b/conf/esx.conf
@@ -56,3 +56,6 @@ ip = 192.168.122.105
 # (Optional) Set your own tags. These are comma separated and help to identify
 # specific VMs. You can run samples on VMs with tag you require.
 # tags = windows_xp_sp3,32_bit,acrobat_reader_6
+
+# (Optional) Set a memory profile for volatility to use, specific to this machine.
+# volatility_profile = WinXPSP2x86

--- a/lib/cuckoo/common/abstracts.py
+++ b/lib/cuckoo/common/abstracts.py
@@ -112,6 +112,10 @@ class Machinery(object):
                 # empty and use default behaviour.
                 machine.snapshot = machine_opts.get("snapshot")
 
+                #If available, get OS based volatiliy profile
+                machine.volatility_profile = machine_opts.get("volatility_profile")
+                
+                
                 # If configured, use specific resultserver IP and port,
                 # else use the default value.
                 opt_resultserver = self.options_globals.resultserver
@@ -139,7 +143,8 @@ class Machinery(object):
                                     interface=machine.interface,
                                     snapshot=machine.snapshot,
                                     resultserver_ip=ip,
-                                    resultserver_port=port)
+                                    resultserver_port=port,
+                                    volatility_profile=machine.volatility_profile)
             except (AttributeError, CuckooOperationalError) as e:
                 log.warning("Configuration details about machine %s "
                             "are missing: %s", machine_id, e)
@@ -600,6 +605,7 @@ class Processing(object):
         self.logs_path = ""
         self.task = None
         self.options = None
+        self.machine = None
 
     def set_options(self, options):
         """Set report options.
@@ -627,6 +633,9 @@ class Processing(object):
         self.pcap_path = os.path.join(self.analysis_path, "dump.pcap")
         self.pmemory_path = os.path.join(self.analysis_path, "memory")
         self.memory_path = os.path.join(self.analysis_path, "memory.dmp")
+
+    def set_machine(self, machine):
+        self.machine = machine
 
     def run(self):
         """Start processing.

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -29,7 +29,7 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
-SCHEMA_VERSION = "3aa42d870199"
+SCHEMA_VERSION = "37d61512fbf7"
 TASK_PENDING = "pending"
 TASK_RUNNING = "running"
 TASK_COMPLETED = "completed"

--- a/lib/cuckoo/core/plugins.py
+++ b/lib/cuckoo/core/plugins.py
@@ -137,9 +137,10 @@ class RunProcessing(object):
     is then passed over the reporting engine.
     """
 
-    def __init__(self, task_id):
+    def __init__(self, task_id, machine):
         """@param task_id: ID of the analyses to process."""
         self.task = Database().view_task(task_id).to_dict()
+        self.machine = machine
         self.analysis_path = os.path.join(CUCKOO_ROOT, "storage", "analyses", str(task_id))
         self.cfg = Config("processing")
 
@@ -179,6 +180,8 @@ class RunProcessing(object):
         current.set_task(self.task)
         # Give it the options from the relevant processing.conf section.
         current.set_options(options)
+        
+        current.set_machine(self.machine)
 
         try:
             # Run the processing module and retrieve the generated data to be

--- a/lib/cuckoo/core/scheduler.py
+++ b/lib/cuckoo/core/scheduler.py
@@ -320,7 +320,7 @@ class AnalysisManager(Thread):
 
     def process_results(self):
         """Process the analysis results and generate the enabled reports."""
-        results = RunProcessing(task_id=self.task.id).run()
+        results = RunProcessing(task_id=self.task.id, machine=self.machine).run()
         RunSignatures(results=results).run()
         RunReporting(task_id=self.task.id, results=results).run()
 

--- a/utils/db_migration/versions/update_machine_table_to_include_volatility_profile.py
+++ b/utils/db_migration/versions/update_machine_table_to_include_volatility_profile.py
@@ -1,0 +1,34 @@
+# Copyright (C) 2010-2015 Cuckoo Foundation.
+# This file is part of Cuckoo Sandbox - http://www.cuckoosandbox.org
+# See the file 'docs/LICENSE' for copying permission.
+
+"""update machine table to include volatility profile
+
+Revision ID: 37d61512fbf7
+Revises: 495d5a6edef3
+Create Date: 2015-05-20 10:01:54.097856
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '37d61512fbf7'
+down_revision = '495d5a6edef3'
+
+from alembic import op
+import os.path
+import sqlalchemy as sa
+import sys
+
+curdir = os.path.abspath(os.path.dirname(__file__))
+sys.path.append(os.path.join(curdir, "..", ".."))
+
+import lib.cuckoo.core.database as db
+
+def _perform(upgrade):
+    op.add_column('machines', sa.Column('volatility_profile', sa.String(255)))
+
+def upgrade():
+    _perform(upgrade=True)
+
+def downgrade():
+    _perform(upgrade=False)


### PR DESCRIPTION
This allows cuckoo to run volatility against more than 1 OS type
if your setup has various guest configurations.

DB update script in migration folder required to store machine level
volatility profile.

esx.conf has example of volatility_profile machine setting
  the same setting can be used for guest machines
  in whatever machine configuration used

abstracts.py adds machine object to the processing class.

plugins.py passes machine level information to the modules.

memory.py passes volatility profile information to the volatilty API
  also has changes to handle 64 bit addresses
  as well as changes to disable volatility plugins
  that do not support 64 bit profiles (e.g. idt)

scheduler.py passes machine level information to the processing module.

database.py updated with the new database schema version.