### PR TITLE
Added: removal of sorted_pcap data when deleting analyses

### DIFF
--- a/web/analysis/views.py
+++ b/web/analysis/views.py
@@ -392,6 +392,11 @@ def remove(request, task_id):
             # Delete network pcap.
             if "pcap_id" in analysis["network"] and results_db.analysis.find({"network.pcap_id": ObjectId(analysis["network"]["pcap_id"])}).count() == 1:
                 fs.delete(ObjectId(analysis["network"]["pcap_id"]))
+            
+            # Delete sorted pcap
+            if "sorted_pcap_id" in analysis["network"] and results_db.analysis.find({"network.sorted_pcap_id": ObjectId(analysis["network"]["sorted_pcap_id"])}).count() == 1:
+                fs.delete(ObjectId(analysis["network"]["sorted_pcap_id"]))
+                
             # Delete dropped.
             for drop in analysis["dropped"]:
                 if "object_id" in drop and results_db.analysis.find({"dropped.object_id": ObjectId(drop["object_id"])}).count() == 1:


### PR DESCRIPTION
When deleting analyses from the web interface, sorted pcap data files are left behind in the reporting database.  Update removes these orphans.