### PR TITLE
Fix #524 add if for render link to sample in file details table

### DIFF
--- a/web/templates/analysis/overview/_file.html
+++ b/web/templates/analysis/overview/_file.html
@@ -54,7 +54,13 @@
             </tr>
             <tr>
                 <th></th>
-                <td><a class="btn btn-primary btn-small" href="{% url "analysis.views.file" "sample" analysis.target.file_id %}">Download</a></td>
+                <td>
+                {% if analysis.target.file_id %}
+                    <a class="btn btn-primary btn-small" href="{% url "analysis.views.file" "sample" analysis.target.file_id %}">Download</a>
+                {% else %}
+                    Sample not found
+                {% endif %}
+                </td>
             </tr>
         </table>
     </div>


### PR DESCRIPTION
This fix #524 with a if in template for render button for download sample only when it is found. If it's not render never then it's not found for other reason that a symblink error as I say in #524 that I has this warning. @botherder If all well then with this fixed I can migrate https://github.com/cuckoobox/cuckoo/pull/542 to Django report and advance other step in #564 task.