### PR TITLE
Issue deleting tasks with identical tags

### DIFF
--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -114,7 +114,7 @@ class Tag(Base):
     __tablename__ = "tags"
 
     id = Column(Integer(), primary_key=True)
-    name = Column(String(255), nullable=False, unique=True)
+    name = Column(String(255), nullable=False, unique=False)
 
     def __repr__(self):
         return "<Tag('{0}','{1}')>".format(self.id, self.name)
@@ -411,19 +411,6 @@ class Database(object):
                                         "import %s (install with `pip "
                                         "install %s`)" % (lib, lib))
 
-    def _get_or_create(self, session, model, **kwargs):
-        """Get an ORM instance or create it if not exist.
-        @param session: SQLAlchemy session object
-        @param model: model to query
-        @return: row instance
-        """
-        instance = session.query(model).filter_by(**kwargs).first()
-        if instance:
-            return instance
-        else:
-            instance = model(**kwargs)
-            return instance
-
     @classlock
     def drop(self):
         """Drop all tables."""
@@ -476,7 +463,7 @@ class Database(object):
         if tags:
             for tag in tags.split(","):
                 if tag.strip():
-                    tag = self._get_or_create(session, Tag, name=tag.strip())
+                    tag = Tag(name=tag.strip())
                     machine.tags.append(tag)
         session.add(machine)
 
@@ -849,7 +836,7 @@ class Database(object):
         # Deal with tags format (i.e., foo,bar,baz)
         if tags:
             for tag in tags.split(","):
-                tag = self._get_or_create(session, Tag, name=tag.strip())
+                tag = Tag(name=tag.strip())
                 task.tags.append(tag)
 
         if clock:

--- a/lib/cuckoo/core/database.py
+++ b/lib/cuckoo/core/database.py
@@ -16,7 +16,7 @@ from lib.cuckoo.common.objects import File, URL
 from lib.cuckoo.common.utils import create_folder, Singleton, classlock, SuperLock
 
 try:
-    from sqlalchemy import create_engine, Column
+    from sqlalchemy import create_engine, Column, event
     from sqlalchemy import Integer, String, Boolean, DateTime, Enum
     from sqlalchemy import ForeignKey, Text, Index, Table
     from sqlalchemy.ext.declarative import declarative_base
@@ -62,8 +62,7 @@ class Machine(Base):
     label = Column(String(255), nullable=False)
     ip = Column(String(255), nullable=False)
     platform = Column(String(255), nullable=False)
-    tags = relationship("Tag", secondary=machines_tags, cascade="all, delete",
-                        single_parent=True, backref=backref("machine", cascade="all"))
+    tags = relationship("Tag", secondary=machines_tags, backref="machines")
     interface = Column(String(255), nullable=True)
     snapshot = Column(String(255), nullable=True)
     locked = Column(Boolean(), nullable=False, default=False)
@@ -114,7 +113,7 @@ class Tag(Base):
     __tablename__ = "tags"
 
     id = Column(Integer(), primary_key=True)
-    name = Column(String(255), nullable=False, unique=False)
+    name = Column(String(255), nullable=False, unique=True)
 
     def __repr__(self):
         return "<Tag('{0}','{1}')>".format(self.id, self.name)
@@ -256,9 +255,7 @@ class Task(Base):
     owner = Column(String(64), nullable=True)
     machine = Column(String(255), nullable=True)
     package = Column(String(255), nullable=True)
-    tags = relationship("Tag", secondary=tasks_tags, cascade="all, delete",
-                        single_parent=True, backref=backref("task", cascade="all"),
-                        lazy="subquery")
+    tags = relationship("Tag", secondary=tasks_tags, backref="tasks", lazy="subquery")
     options = Column(String(255), nullable=True)
     platform = Column(String(255), nullable=True)
     memory = Column(Boolean, nullable=False, default=False)
@@ -362,6 +359,10 @@ class Database(object):
         # Get db session.
         self.Session = sessionmaker(bind=self.engine)
 
+        @event.listens_for(self.Session, 'after_flush')
+        def delete_tag_orphans(session, ctx):
+            session.query(Tag).filter(~Tag.tasks.any()).filter(~Tag.machines.any()).delete(synchronize_session=False)
+
         # Deal with schema versioning.
         # TODO: it's a little bit dirty, needs refactoring.
         tmp_session = self.Session()
@@ -410,6 +411,19 @@ class Database(object):
             raise CuckooDependencyError("Missing database driver, unable to "
                                         "import %s (install with `pip "
                                         "install %s`)" % (lib, lib))
+
+    def _get_or_create(self, session, model, **kwargs):
+        """Get an ORM instance or create it if not exist.
+        @param session: SQLAlchemy session object
+        @param model: model to query
+        @return: row instance
+        """
+        instance = session.query(model).filter_by(**kwargs).first()
+        if instance:
+            return instance
+        else:
+            instance = model(**kwargs)
+            return instance
 
     @classlock
     def drop(self):
@@ -463,7 +477,7 @@ class Database(object):
         if tags:
             for tag in tags.split(","):
                 if tag.strip():
-                    tag = Tag(name=tag.strip())
+                    tag = self._get_or_create(session, Tag, name=tag.strip())
                     machine.tags.append(tag)
         session.add(machine)
 
@@ -836,7 +850,7 @@ class Database(object):
         # Deal with tags format (i.e., foo,bar,baz)
         if tags:
             for tag in tags.split(","):
-                tag = Tag(name=tag.strip())
+                tag = self._get_or_create(session, Tag, name=tag.strip())
                 task.tags.append(tag)
 
         if clock:


### PR DESCRIPTION
I have found that if several tasks are submitted with a given tag, deleting a single task via the API deletes all of the tasks.

Appears to be an issue with the unique constraint on the tags.names column and the bi-directional relationships between the tasks, tasks_tags and tags tables as defined in database.py.  

Adding two samples with tag 'a':

curl -F file=@/tmp/sample.exe --form_string "tags=a" http://server/tasks/create/file
curl -F file=@/tmp/sample2.exe --form_string "tags=a" http://server/tasks/create/file

sees the following in the DB tables:

**tasks**
id=1, target=sample.exe
id=2, target=sample.exe

**tasks_tags**
task_id=1, tag_id=1
task_id=2, tag_id=1

**tags**
id=1, name=a


Then issuing 'curl http://server/tasks/delete/1', both tasks 1 and 2 are deleted and I am left with:

**tasks**

**tasks_tags**

**tags**


Both tasks have been deleted despite only requesting task 1 to be deleted.

The proposed change addresses the issue. 