### PR TITLE
Fix shallow copy bug in MongoDB reporting module

### DIFF
--- a/modules/reporting/mongodb.py
+++ b/modules/reporting/mongodb.py
@@ -3,6 +3,7 @@
 # See the file 'docs/LICENSE' for copying permission.
 
 import os
+import copy
 
 from lib.cuckoo.common.abstracts import Report
 from lib.cuckoo.common.exceptions import CuckooDependencyError
@@ -103,7 +104,7 @@ class MongoDB(Report):
         # Create a copy of the dictionary. This is done in order to not modify
         # the original dictionary and possibly compromise the following
         # reporting modules.
-        report = dict(results)
+        report = copy.deepcopy(results)
         if not "network" in report:
             report["network"] = {}
 


### PR DESCRIPTION
MongoDB reporting module makes a shallow copy of `results` dict instead of a deep copy.
This behaviour can affect other reporting modules.