### PR TITLE
Update esx.conf

### DIFF
--- a/conf/esx.conf
+++ b/conf/esx.conf
@@ -32,7 +32,7 @@ ip = 192.168.122.105
 
 # (Optional) Specify the name of the network interface that should be used
 # when dumping network traffic from this machine with tcpdump. If specified,
-# overrides the default interface specified in cuckoo.conf
+# overrides the default interface specified in auxiliary.conf
 # Example (eth0 is the interface name):
 # interface = eth0
 


### PR DESCRIPTION
this is identical for all the virtual-conf files. If the interface is set it will override the default interface specified in AUXILIARY.CONF and not the cuckoo.conf ( recently changed )