### PR TITLE
fix virustotal send file to analysis

### DIFF
--- a/lib/cuckoo/common/virustotal.py
+++ b/lib/cuckoo/common/virustotal.py
@@ -28,13 +28,15 @@ class VirusTotalAPI(object):
     FILE_SCAN = "https://www.virustotal.com/vtapi/v2/file/scan"
     URL_SCAN = "https://www.virustotal.com/vtapi/v2/url/scan"
 
-    def __init__(self, apikey, timeout):
+    def __init__(self, apikey, timeout, scan=0):
         """Initialize VirusTotal API with the API key and timeout.
         @param api_key: virustotal api key
         @param timeout: request and response timeout
+        @param scan: send file to scan or just get report
         """
         self.apikey = apikey
         self.timeout = timeout
+        self.scan = scan
 
     def _request_json(self, url, **kwargs):
         """Wrapper around doing a request and parsing its JSON output."""
@@ -59,11 +61,14 @@ class VirusTotalAPI(object):
         # This URL has not been analyzed yet - send a request to analyze it
         # and return with the permalink.
         if not r.get("response_code"):
-            return {
-                "summary": {
-                    "error": "resource has not been scanned yet",
+            if self.scan:
+                raise VirusTotalResourceNotScanned
+            else:
+                return {
+                    "summary": {
+                        "error": "resource has not been scanned yet",
+                    }
                 }
-            }
 
         results = {
             "summary": {

--- a/modules/processing/virustotal.py
+++ b/modules/processing/virustotal.py
@@ -29,14 +29,14 @@ class VirusTotal(Processing):
 
         apikey = self.options.get("key")
         timeout = int(self.options.get("timeout", 60))
-        self.scan = int(self.options.get("scan", 0))
+        scan = int(self.options.get("scan", 0))
 
         if not apikey:
             raise CuckooProcessingError("VirusTotal API key not "
                                         "configured, skipping VirusTotal "
                                         "processing module.")
 
-        self.vt = VirusTotalAPI(apikey, timeout)
+        self.vt = VirusTotalAPI(apikey, timeout, scan)
 
         # Scan the original sample or URL.
         if self.task["category"] == "file":
@@ -69,8 +69,7 @@ class VirusTotal(Processing):
         try:
             return self.vt.file_report(filepath, summary=summary)
         except VirusTotalResourceNotScanned:
-            if self.scan:
-                return self.vt.file_scan(filepath)
+            return self.vt.file_scan(filepath)
         except CuckooOperationalError as e:
             log.warning("Error fetching results from VirusTotal for "
                         "\"%s\": %s", os.path.basename(filepath), e.message)
@@ -83,8 +82,7 @@ class VirusTotal(Processing):
         try:
             return self.vt.url_report(url, summary=summary)
         except VirusTotalResourceNotScanned:
-            if self.scan:
-                return self.vt.url_scan(url)
+            return self.vt.url_scan(url)
         except CuckooOperationalError as e:
             log.warning("Error fetching results from VirusTotal for "
                         "\"%s\": %s", url, e.message)

--- a/web/templates/analysis/static/_antivirus.html
+++ b/web/templates/analysis/static/_antivirus.html
@@ -33,6 +33,10 @@
         {% endfor %}
     </table>
     {% else %}
-    No antivirus signatures available.
+        {% if analysis.virustotal.summary.permalink %}
+            <a href="{{analysis.virustotal.summary.permalink}}">Your file is being analysed</a>
+        {% else %}
+            No antivirus signatures available.
+        {% endif %}
     {% endif %}
 </section>


### PR DESCRIPTION
There is option "scan" for VirusTotal in current version of Cuckoo, but it does not work, always return "No antivirus signatures available." if file is new.

These changes fix it, returning url for analysis