### PR TITLE
Add API call to get analysis package's files

### DIFF
--- a/docs/book/src/usage/api.rst
+++ b/docs/book/src/usage/api.rst
@@ -427,7 +427,7 @@ Following is a list of currently available resources and a brief description of 
 
         **Parameters**:
             * ``id`` *(required)* *(int)* - ID of the task to get the report for
-            * ``format`` *(optional)* - format of the report to retrieve [json/html/all/dropped]. If none is specified the JSON report will be returned. ``all`` returns all the result files as tar.bz2, ``dropped`` the dropped files as tar.bz2
+            * ``format`` *(optional)* - format of the report to retrieve [json/html/all/dropped/package_files]. If none is specified the JSON report will be returned. ``all`` returns all the result files as tar.bz2, ``dropped`` the dropped files as tar.bz2, ``package_files`` files uploaded to host by analysis packages.
 
         **Status codes**:
             * ``200`` - no error

--- a/utils/api.py
+++ b/utils/api.py
@@ -255,6 +255,7 @@ def tasks_report(task_id, report_format="json"):
     bz_formats = {
         "all": {"type": "-", "files": ["memory.dmp"]},
         "dropped": {"type": "+", "files": ["files"]},
+        "package_files": {"type": "+", "files": ["package_files"]},
     }
 
     tar_formats = {


### PR DESCRIPTION
Add `/tasks/report/<task-id>/package_files` API call to be able to retrieve files uploaded to host by analysis packages.
The name `package_files` is not really relevant but I didn't find something else... `analysis`, `analysis_package`... ? Actually I just took the name of the folder where those files are uploaded. The choose of using an underscore is also to discuss.