### PR TITLE
Fixed pid/ppid in JSON behavior

### DIFF
--- a/modules/processing/behavior.py
+++ b/modules/processing/behavior.py
@@ -120,7 +120,7 @@ class GenericBehavior(BehaviorHandler):
 
         self.processes[process["pid"]] = {
             "pid": process["pid"],
-            "pid": process["ppid"],
+            "ppid": process["ppid"],
             "process_name": process["process_name"],
             "first_seen": process["first_seen"],
             "summary": collections.defaultdict(set),


### PR DESCRIPTION
In regard issue #702, I think I found the typo. The pids appear to be correct now.